### PR TITLE
chore(KFLUXVNGD-30): Use Openshift CI multi-arch API

### DIFF
--- a/pipelines/integration/provision-cluster.yaml
+++ b/pipelines/integration/provision-cluster.yaml
@@ -56,9 +56,9 @@ spec:
               resolver: git
               params:
                 - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
+                  value: https://github.com/hmariset/build-definitions.git
                 - name: revision
-                  value: main
+                  value: update-stepaction-multiarch
                 - name: pathInRepo
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:


### PR DESCRIPTION
When getting latest version use the openshift CI multi-arch API instead of amd64 specific API.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-30